### PR TITLE
Better async WMI data fetching and better handling for decimal data types

### DIFF
--- a/PluginWMI/PluginWMI.cpp
+++ b/PluginWMI/PluginWMI.cpp
@@ -30,9 +30,11 @@ struct Measure
 {
 	Measure() : refreshInterval(60), lastUpdate(0) {}
 
+	std::mutex* valueMutex;
 	EResultType type;
 	double dblResult;
 	std::wstring strResult;
+	std::wstring strResult2;
 	std::wstring query;
 	int refreshInterval;
 	int lastUpdate;
@@ -60,11 +62,13 @@ void QueryWorker()
 			g_queue.pop();
 		} // unlock
 
-		if (!srv.Exec(m->query, m->strResult, m->dblResult, m->type))
 		{
-			// show error tag
-			m->type = eString;
-			m->strResult = L"#Error";
+			std::unique_lock<std::mutex> lg(*m->valueMutex);
+			if (!srv.Exec(m->query, m->strResult, m->dblResult, m->type)) {
+				// show error tag
+				m->type = eString;
+				m->strResult = L"#Error";
+			}
 		}
 		m->queued = false;
 	}
@@ -78,74 +82,73 @@ void EnqueueForUpdate(Measure *m)
 	g_cv.notify_one();
 }
 
-PLUGIN_EXPORT void Initialize(void** data, void* rm)
-{
-	if (g_measuresCnt == 0) // first time initialization
-	{
-		// start WMI query thread
-		// waits for main thread to put Measures on g_queue for processing
-		g_worker.swap(std::thread(QueryWorker));
+extern "C" {
+
+	PLUGIN_EXPORT void Initialize(void** data, void* rm) {
+		if (g_measuresCnt == 0) // first time initialization
+		{
+			// start WMI query thread
+			// waits for main thread to put Measures on g_queue for processing
+			g_worker.swap(std::thread(QueryWorker));
+		}
+		Measure* measure = new Measure;
+		measure->valueMutex = new std::mutex;
+		*data = measure;
+		++g_measuresCnt;
 	}
 
-	Measure* measure = new Measure;
-	*data = measure;
-	++g_measuresCnt;
-}
-
-PLUGIN_EXPORT void Reload(void* data, void* rm, double* maxValue)
-{
-	Measure* measure = (Measure*)data;
-	measure->refreshInterval = RmReadInt(rm, L"Refresh", 60);
-	measure->query = RmReadString(rm, L"Query", L"");
-	measure->lastUpdate = 0;
-}
-
-PLUGIN_EXPORT double Update(void* data)
-{
-	Measure* m = (Measure*)data;
-	DWORD now = ::GetTickCount() / 1000;
-	if (now - m->lastUpdate >= m->refreshInterval)
-	{
-		Measure copy = *m;
-		EnqueueForUpdate(m);
-		m->lastUpdate = now;
-		m = &copy;
+	PLUGIN_EXPORT void Reload(void* data, void* rm, double* maxValue) {
+		Measure* measure = (Measure*)data;
+		measure->refreshInterval = RmReadInt(rm, L"Refresh", 60);
+		measure->query = RmReadString(rm, L"Query", L"");
+		measure->lastUpdate = 0;
 	}
-	if (m->type == eNum)
-		return m->dblResult;
-	return 0.0;
-}
 
-PLUGIN_EXPORT LPCWSTR GetString(void* data)
-{
-	Measure* measure = (Measure*)data;
-	if (!measure->queued)
-	{
-		if (measure->type == eString)
-			return measure->strResult.c_str();
-		else return nullptr; // rainmeter will treat this measure as number
+	PLUGIN_EXPORT double Update(void* data) {
+		Measure* m = (Measure*)data;
+		DWORD now = ::GetTickCount() / 1000;
+		if (now - m->lastUpdate >= m->refreshInterval) {
+			Measure copy = *m;
+			EnqueueForUpdate(m);
+			m->lastUpdate = now;
+			m = &copy;
+		}
+		if (m->type == eNum)
+			return m->dblResult;
+		return 0.0;
 	}
-	else return L"#Wait";
-}
 
-//PLUGIN_EXPORT void ExecuteBang(void* data, LPCWSTR args)
-//{
-//	Measure* measure = (Measure*)data;
-//}
-
-PLUGIN_EXPORT void Finalize(void* data)
-{
-	Measure* measure = (Measure*)data;
-	delete measure;
-	--g_measuresCnt;
-	// no more wmi measures, release helper
-	if (g_measuresCnt == 0)
-	{
-		// stop queue thread
-		g_run = false;
-		g_cv.notify_one();
-		g_worker.join();
+	PLUGIN_EXPORT LPCWSTR GetString(void* data) {
+		Measure* measure = (Measure*)data;
+		{
+			std::unique_lock<std::mutex> lg(*measure->valueMutex);
+			if (measure->type == eString)
+				measure->strResult2 = measure->strResult.c_str();
+			else
+				measure->strResult2 = L"";
+		}
+		return measure->strResult2.c_str();
 	}
+
+	//PLUGIN_EXPORT void ExecuteBang(void* data, LPCWSTR args)
+	//{
+	//Measure* measure = (Measure*)data;
+	//}
+
+	PLUGIN_EXPORT void Finalize(void* data) {
+		Measure* measure = (Measure*)data;
+		delete measure->valueMutex;
+		delete measure;
+		--g_measuresCnt;
+		// no more wmi measures, release helper
+		if (g_measuresCnt == 0) {
+			// stop queue thread
+			g_run = false;
+			g_cv.notify_one();
+			g_worker.join();
+		}
+	}
+
 }
 
 

--- a/PluginWMI/WMIService.cpp
+++ b/PluginWMI/WMIService.cpp
@@ -190,7 +190,7 @@ bool CWMIService::Exec(const std::wstring &wmi_query,
 				} break;
 			case VT_R8: {
 				wchar_t buf[24];
-				swprintf((wchar_t*)&buf, 24, L"%.1f", vtProp.dblVal);
+				swprintf((wchar_t*)&buf, 24, L"%.1d", vtProp.dblVal);
 				type = eString;
 				strResult = (wchar_t*)&buf;
 				} break;

--- a/PluginWMI/WMIService.cpp
+++ b/PluginWMI/WMIService.cpp
@@ -91,7 +91,6 @@ bool CWMIService::Connect(LPCWSTR wmi_namespace)
     locator->Release();
 	}
 
-	//RmLog(0, L"WMI.dll: Connected to WMI");
 	return true;
 }
 

--- a/PluginWMI/WMIService.h
+++ b/PluginWMI/WMIService.h
@@ -12,6 +12,9 @@
 #include <comdef.h>
 #include <Wbemidl.h>
 #include <string>
+#include <stdio.h>
+#include <wchar.h>
+#include <mutex>
 
 enum EResultType { eString, eNum };
 


### PR DESCRIPTION
Better async WMI data fetching: No longer display #Wait, data can now be displayed while it is also being updated

Better handling for decimal data types: Convert floating-point and double-precision floating-point data to string, since it appears RainMeter 3 no longer likes to display those values properly (Just shows a 0)
